### PR TITLE
Spawn

### DIFF
--- a/chiika_runtime/src/async_functions.rs
+++ b/chiika_runtime/src/async_functions.rs
@@ -1,23 +1,21 @@
 use crate::chiika_env::ChiikaEnv;
-use crate::{ChiikaCont, ContAndValue, ContFuture};
+use crate::{ChiikaCont, ContFuture};
 use std::future::{poll_fn, Future};
 use std::task::Poll;
 use std::time::Duration;
 
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]
-pub extern "C" fn sleep_sec(_env: &'static mut ChiikaEnv, n: i64, cont: ChiikaCont) -> ContFuture {
-    async fn sleep_sec(n: i64) -> i64 {
+pub extern "C" fn sleep_sec(env: &'static mut ChiikaEnv, n: i64, cont: ChiikaCont) -> ContFuture {
+    async fn sleep_sec(n: i64) -> u64 {
         // Hand written part (all the rest will be macro-generated)
         tokio::time::sleep(Duration::from_secs(n as u64)).await;
         0
     }
+    env.cont = Some(cont);
     let mut future = Box::pin(sleep_sec(n));
-    Box::pin(poll_fn(move |ctx| match future.as_mut().poll(ctx) {
-        Poll::Ready(v) => {
-            let as_void = v as *const i64 as *mut std::ffi::c_void;
-            Poll::Ready(ContAndValue(Some(cont), as_void))
-        }
+    Box::new(poll_fn(move |ctx| match future.as_mut().poll(ctx) {
+        Poll::Ready(v) => Poll::Ready(v),
         Poll::Pending => Poll::Pending,
     }))
 }

--- a/chiika_runtime/src/chiika_env.rs
+++ b/chiika_runtime/src/chiika_env.rs
@@ -4,11 +4,8 @@ type TypeId = u64;
 type EnvItem = (ChiikaValue, TypeId);
 enum EnvFrame {
     NormalFrame(Vec<Option<EnvItem>>),
-    RustFrame(WrappedFuture),
+    RustFrame(ContFuture),
 }
-
-struct WrappedFuture(ContFuture);
-unsafe impl Send for WrappedFuture {}
 
 #[repr(C)]
 pub struct ChiikaEnv {
@@ -39,12 +36,12 @@ impl ChiikaEnv {
     }
 
     pub fn push_rust_frame(&mut self, future: ContFuture) {
-        self.stack.push(EnvFrame::RustFrame(WrappedFuture(future)));
+        self.stack.push(EnvFrame::RustFrame(future));
     }
 
     pub fn pop_rust_frame(&mut self) -> Option<ContFuture> {
         match self.stack.pop() {
-            Some(EnvFrame::RustFrame(WrappedFuture(future))) => Some(future),
+            Some(EnvFrame::RustFrame(future)) => Some(future),
             _ => None,
         }
     }

--- a/chiika_runtime/src/chiika_env.rs
+++ b/chiika_runtime/src/chiika_env.rs
@@ -1,13 +1,17 @@
-use crate::ChiikaCont;
-type ChiikaValue = i64;
-type TypeId = i64;
+use crate::{ChiikaCont, ContFuture};
+type ChiikaValue = u64;
+type TypeId = u64;
 type EnvItem = (ChiikaValue, TypeId);
-type EnvFrame = Vec<Option<EnvItem>>;
+enum EnvFrame {
+    NormalFrame(Vec<Option<EnvItem>>),
+    RustFrame(WrappedFuture),
+}
+
+struct WrappedFuture(ContFuture);
+unsafe impl Send for WrappedFuture {}
 
 #[repr(C)]
-#[derive(Debug)]
 pub struct ChiikaEnv {
-    // Element is either 64-bit integer or 64-bit pointer.
     stack: Vec<EnvFrame>,
     pub cont: Option<ChiikaCont>,
 }
@@ -15,7 +19,7 @@ pub struct ChiikaEnv {
 impl ChiikaEnv {
     pub fn new() -> ChiikaEnv {
         ChiikaEnv {
-            stack: vec![vec![]],
+            stack: vec![],
             cont: None,
         }
     }
@@ -33,22 +37,36 @@ impl ChiikaEnv {
             None => panic!("[BUG;ChiikaEnv::current_frame_mut] Stack underflow: no frame there"),
         }
     }
+
+    pub fn push_rust_frame(&mut self, future: ContFuture) {
+        self.stack.push(EnvFrame::RustFrame(WrappedFuture(future)));
+    }
+
+    pub fn pop_rust_frame(&mut self) -> Option<ContFuture> {
+        match self.stack.pop() {
+            Some(EnvFrame::RustFrame(WrappedFuture(future))) => Some(future),
+            _ => None,
+        }
+    }
 }
 
 /// Push a frame to the stack.
 #[no_mangle]
-pub extern "C" fn chiika_env_push_frame(env: *mut ChiikaEnv, size: i64) {
+pub extern "C" fn chiika_env_push_frame(env: *mut ChiikaEnv, size: u64) {
     unsafe {
         let v = std::iter::repeat(None).take(size as usize).collect();
-        (*env).stack.push(v);
+        (*env).stack.push(EnvFrame::NormalFrame(v));
     }
 }
 
 /// Push an item to the current frame.
 #[no_mangle]
-pub extern "C" fn chiika_env_set(env: *mut ChiikaEnv, n: i64, value: ChiikaValue, type_id: TypeId) {
-    let frame = unsafe { (*env).current_frame_mut() };
-    if n > (frame.len() as i64) - 1 {
+pub extern "C" fn chiika_env_set(env: *mut ChiikaEnv, n: u64, value: ChiikaValue, type_id: TypeId) {
+    let frame_ = unsafe { (*env).current_frame_mut() };
+    let EnvFrame::NormalFrame(frame) = frame_ else {
+        panic!("[BUG;chiika_env_set] Rust frame is on the top");
+    };
+    if n > (frame.len() as u64) - 1 {
         panic!(
             "[BUG;chiika_env_set] Index out of bounds: n={}, frame_size={}",
             n,
@@ -61,10 +79,10 @@ pub extern "C" fn chiika_env_set(env: *mut ChiikaEnv, n: i64, value: ChiikaValue
 /// Pop last frame from the stack and returns its first item.
 /// Panics if the frame size is not as expected.
 #[no_mangle]
-pub extern "C" fn chiika_env_pop_frame(env: *mut ChiikaEnv, expected_len: i64) -> i64 {
+pub extern "C" fn chiika_env_pop_frame(env: *mut ChiikaEnv, expected_len: u64) -> u64 {
     let frame = unsafe { (*env).stack.pop() };
     match frame {
-        Some(v) => {
+        Some(EnvFrame::NormalFrame(v)) => {
             if v.len() != expected_len as usize {
                 panic!(
                     "[BUG;chiika_env_pop_frame] Frame size mismatch: expected size={}, but got size={}",
@@ -74,15 +92,21 @@ pub extern "C" fn chiika_env_pop_frame(env: *mut ChiikaEnv, expected_len: i64) -
             }
             v.first().unwrap().unwrap().0
         }
+        Some(EnvFrame::RustFrame(_)) => {
+            panic!("[BUG;chiika_env_pop_frame] Rust frame is on the top");
+        }
         None => panic!("[BUG;chiika_env_pop_frame] Stack underflow: no frame to pop"),
     }
 }
 
 /// Peek the n-th last item in the current frame.
 #[no_mangle]
-pub extern "C" fn chiika_env_ref(env: *mut ChiikaEnv, n: i64, expected_type_id: TypeId) -> i64 {
-    let frame = unsafe { (*env).current_frame() };
-    if n > (frame.len() as i64) - 1 {
+pub extern "C" fn chiika_env_ref(env: *mut ChiikaEnv, n: u64, expected_type_id: TypeId) -> u64 {
+    let frame_ = unsafe { (*env).current_frame() };
+    let EnvFrame::NormalFrame(frame) = frame_ else {
+        panic!("[BUG;chiika_env_ref] Rust frame is on the top");
+    };
+    if n > (frame.len() as u64) - 1 {
         panic!(
             "[BUG;chiika_env_ref] Index out of bounds: n={}, frame_size={}",
             n,

--- a/chiika_runtime/src/chiika_env.rs
+++ b/chiika_runtime/src/chiika_env.rs
@@ -1,3 +1,4 @@
+use crate::ChiikaCont;
 type ChiikaValue = i64;
 type TypeId = i64;
 type EnvItem = (ChiikaValue, TypeId);
@@ -8,12 +9,14 @@ type EnvFrame = Vec<Option<EnvItem>>;
 pub struct ChiikaEnv {
     // Element is either 64-bit integer or 64-bit pointer.
     stack: Vec<EnvFrame>,
+    pub cont: Option<ChiikaCont>,
 }
 
 impl ChiikaEnv {
     pub fn new() -> ChiikaEnv {
         ChiikaEnv {
             stack: vec![vec![]],
+            cont: None,
         }
     }
 

--- a/chiika_runtime/src/lib.rs
+++ b/chiika_runtime/src/lib.rs
@@ -27,7 +27,7 @@ pub type ContFuture = Box<dyn Future<Output = ChiikaValue> + Unpin + Send>;
 type ChiikaCont = extern "C" fn(env: *mut ChiikaEnv, value: ChiikaValue) -> ContFuture;
 
 #[allow(improper_ctypes_definitions)]
-type ChiikaThunk = extern "C" fn(env: *mut ChiikaEnv, cont: ChiikaCont) -> ContFuture;
+type ChiikaThunk = unsafe extern "C" fn(env: *mut ChiikaEnv, cont: ChiikaCont) -> ContFuture;
 
 #[allow(improper_ctypes)]
 extern "C" {
@@ -45,11 +45,32 @@ extern "C" fn chiika_finish(env: *mut ChiikaEnv, _v: ChiikaValue) -> ContFuture 
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn chiika_spawn(f: ChiikaThunk) -> u64 {
+    let poller = make_poller(f);
+    tokio::spawn(poller);
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn chiika_start_tokio(_: u64) -> u64 {
+    let poller = make_poller(chiika_start_user);
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(poller);
+
+    // Q: Need this?
+    // sleep(Duration::from_millis(50)).await;
+
+    0
+}
+
+fn make_poller(f: ChiikaThunk) -> impl Future<Output = ()> {
     let mut env = ChiikaEnv::new();
-    let poller = poll_fn(move |context| loop {
+    poll_fn(move |context| loop {
         let future = env
             .pop_rust_frame()
-            .unwrap_or_else(|| f(&mut env, chiika_finish));
+            .unwrap_or_else(|| unsafe { f(&mut env, chiika_finish) });
         let mut pinned = Pin::new(future);
         let tmp = pinned.as_mut().poll(context);
         match tmp {
@@ -66,42 +87,5 @@ pub extern "C" fn chiika_spawn(f: ChiikaThunk) -> u64 {
                 return Poll::Pending;
             }
         }
-    });
-    tokio::spawn(poller);
-    0
-}
-
-#[no_mangle]
-pub extern "C" fn chiika_start_tokio(_: u64) -> u64 {
-    let mut env = ChiikaEnv::new();
-    let mut future: Option<_> = None;
-    let poller = poll_fn(move |context| loop {
-        if future.is_none() {
-            future = Some(unsafe { chiika_start_user(&mut env, chiika_finish) });
-        }
-        let pinned = Pin::new(future.as_mut().unwrap());
-        let tmp = pinned.poll(context);
-        match tmp {
-            Poll::Ready(value) => {
-                if let Some(cont) = env.cont {
-                    let new_future = cont(&mut env, value);
-                    future = Some(new_future);
-                } else {
-                    return Poll::Ready(());
-                }
-            }
-            Poll::Pending => return Poll::Pending,
-        }
-    });
-
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(poller);
-
-    // Q: Need this?
-    // sleep(Duration::from_millis(50)).await;
-
-    0
+    })
 }

--- a/chiika_runtime/src/lib.rs
+++ b/chiika_runtime/src/lib.rs
@@ -21,7 +21,7 @@ use std::task::Poll;
 pub type ChiikaValue = u64;
 
 #[allow(improper_ctypes_definitions)]
-pub type ContFuture = Box<dyn Future<Output = ChiikaValue> + Unpin>;
+pub type ContFuture = Box<dyn Future<Output = ChiikaValue> + Unpin + Send>;
 
 #[allow(improper_ctypes_definitions)]
 type ChiikaCont = extern "C" fn(env: *mut ChiikaEnv, value: ChiikaValue) -> ContFuture;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -52,6 +52,7 @@ pub enum Expr {
     If(Box<Expr>, Vec<Expr>, Option<Vec<Expr>>),
     Yield(Box<Expr>),
     While(Box<Expr>, Vec<Expr>),
+    Spawn(Box<Expr>),
     Alloc(String),
     Assign(String, Box<Expr>),
     Return(Box<Expr>),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -202,7 +202,7 @@ impl<'c> Compiler<'c> {
             }
             hir::Expr::BlockArgRef => self.compile_block_arg_ref(block),
             hir::Expr::Nop => Ok(None),
-            //_ => panic!("should be lowered before compiler.rs: {:?}", texpr.0),
+            _ => panic!("should be lowered before compiler.rs: {:?}", texpr.0),
         }
     }
 

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -15,6 +15,7 @@ pub enum Expr {
     If(Box<Typed<Expr>>, Vec<Typed<Expr>>, Vec<Typed<Expr>>),
     Yield(Box<Typed<Expr>>),
     While(Box<Typed<Expr>>, Vec<Typed<Expr>>),
+    Spawn(Box<Typed<Expr>>),
     Alloc(String),
     Assign(String, Box<Typed<Expr>>),
     Return(Box<Typed<Expr>>),
@@ -102,6 +103,7 @@ impl std::fmt::Display for Expr {
                 }
                 write!(f, "}}")
             }
+            Expr::Spawn(e) => write!(f, "spawn {}", e.0),
             Expr::Alloc(name) => write!(f, "alloc {}", name),
             Expr::Assign(name, e) => write!(f, "{} = {}", name, e.0),
             Expr::Return(e) => write!(f, "return {}  # {}", e.0, e.1),
@@ -121,14 +123,6 @@ impl Expr {
     pub fn number(n: i64) -> TypedExpr {
         (Expr::Number(n), Ty::Int)
     }
-
-    //pub fn pseudo_var(pv: PseudoVar) -> TypedExpr {
-    //    let t = match pv {
-    //        PseudoVar::True | PseudoVar::False => Ty::Bool,
-    //        PseudoVar::Null => Ty::Null,
-    //    };
-    //    (Expr::PseudoVar(pv), t)
-    //}
 
     pub fn lvar_ref(name: impl Into<String>, ty: Ty) -> TypedExpr {
         (Expr::LVarRef(name.into()), ty)
@@ -194,6 +188,10 @@ impl Expr {
             panic!("[BUG] while cond not bool: {:?}", cond);
         }
         (Expr::While(Box::new(cond), body), Ty::Null)
+    }
+
+    pub fn spawn(e: TypedExpr) -> TypedExpr {
+        (Expr::Spawn(Box::new(e)), Ty::Void)
     }
 
     pub fn alloc(name: impl Into<String>) -> TypedExpr {

--- a/src/hir/rewriter.rs
+++ b/src/hir/rewriter.rs
@@ -43,6 +43,7 @@ pub trait HirRewriter {
             hir::Expr::While(cond_expr, body_exprs) => {
                 hir::Expr::while_(self.walk_expr(*cond_expr)?, self.walk_exprs(body_exprs)?)
             }
+            hir::Expr::Spawn(expr) => hir::Expr::spawn(self.walk_expr(*expr)?),
             hir::Expr::Alloc(_) => expr,
             hir::Expr::Assign(name, rhs) => hir::Expr::assign(name, self.walk_expr(*rhs)?),
             hir::Expr::Return(expr) => hir::Expr::return_(self.walk_expr(*expr)?),

--- a/src/hir/typing.rs
+++ b/src/hir/typing.rs
@@ -128,6 +128,10 @@ impl<'f> Typing<'f> {
                 self.compile_exprs(lvars, body)?;
                 e.1 = hir::Ty::Void;
             }
+            hir::Expr::Spawn(func) => {
+                self.compile_expr(lvars, func)?;
+                e.1 = hir::Ty::Void;
+            }
             hir::Expr::Alloc(name) => {
                 // Milika vars are always Int now
                 lvars.insert(name.clone(), hir::Ty::Int);

--- a/src/hir/untyped.rs
+++ b/src/hir/untyped.rs
@@ -112,6 +112,10 @@ impl Compiler {
                 let body = self.compile_exprs(f, lvars, &body)?;
                 hir::Expr::While(Box::new(cond), body)
             }
+            ast::Expr::Spawn(func) => {
+                let func = self.compile_expr(f, lvars, func)?;
+                hir::Expr::Spawn(Box::new(func))
+            }
             ast::Expr::Alloc(name) => {
                 lvars.insert(name.clone());
                 hir::Expr::Alloc(name.clone())

--- a/src/hir/visitor.rs
+++ b/src/hir/visitor.rs
@@ -54,6 +54,9 @@ pub trait HirVisitor {
                     self.walk_expr(expr)?;
                 }
             }
+            hir::Expr::Spawn(expr) => {
+                self.walk_expr(expr)?;
+            }
             hir::Expr::Alloc(_) => {}
             hir::Expr::Assign(_, rhs) => {
                 self.walk_expr(rhs)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,6 +72,7 @@ peg::parser! {
       / if()
       / yield()
       / while()
+      / spawn()
       / return()
       / assign()
       / equality()
@@ -94,6 +95,9 @@ peg::parser! {
       = "while" _ cond:expr() _ "{" _ stmts:stmts() _ "}" {
         ast::Expr::While(Box::new(cond), stmts)
       }
+
+    rule spawn() -> ast::Expr
+      = "spawn" _ func:expr() { ast::Expr::Spawn(Box::new(func)) }
 
     rule return() -> ast::Expr
       = "return" _ e:expr() { ast::Expr::Return(Box::new(e)) }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,7 @@ pub fn prelude_funcs(main_is_async: bool) -> String {
         extern chiika_env_set(ENV env, Int idx, ANY obj, Int type_id) -> Null
         extern chiika_env_pop_frame(ENV env, Int expected_len) -> ANY
         extern chiika_env_ref(ENV env, Int idx, Int expected_type_id) -> Int
+        extern chiika_spawn(FN((ENV,FN((ENV,Null)->FUTURE))->FUTURE) f) -> Null
         extern chiika_start_tokio(Int n) -> Int
         fun chiika_start_user(ENV env, FN((ENV,Int)->FUTURE) cont) -> FUTURE {
     " + call_user_main

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -148,7 +148,7 @@ impl Verifier {
             }
             hir::Expr::BlockArgRef => (),
             hir::Expr::Nop => (),
-            //_ => panic!("not supported by verifier: {:?}", e.0),
+            _ => panic!("not supported by verifier: {:?}", e.0),
         }
         Ok(())
     }


### PR DESCRIPTION
This PR implements `spawn foo`, which executes the function foo (with no argument) in background.

Internally it cals `tokio::spawn`.